### PR TITLE
Fix crashing on Node 0.4.x LTS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const _ = require('lodash')
 const spawn = require('cross-spawn')
 const gutil = require('gulp-util')


### PR DESCRIPTION
`let` and `const` are used without `use strict` which causes a crash on Node 0.4.x. I've added `use strict` which fixes the crashing.